### PR TITLE
chore(deps): Upgrade to Spring Boot 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,13 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.kafka</groupId>
-			<artifactId>spring-kafka</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-kafka</artifactId>
+		</dependency>
+		<!-- Kafka client still requires Jackson 2.x databind at runtime -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 
 		<dependency>
@@ -66,34 +71,23 @@
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>kafka</artifactId>
-			<version>1.21.4</version>
+			<artifactId>testcontainers-kafka</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>redpanda</artifactId>
-			<version>1.21.4</version>
+			<artifactId>testcontainers-redpanda</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>1.21.4</version>
+			<artifactId>testcontainers-junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Don't know why this is needed by IntelliJ -->
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.11.4</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.vintage</groupId>
-			<artifactId>junit-vintage-engine</artifactId>
-			<version>5.11.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.7</version>
+		<version>4.0.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.acme</groupId>

--- a/src/test/java/org/acme/order/ContainersConfiguration.java
+++ b/src/test/java/org/acme/order/ContainersConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.DynamicPropertyRegistrar;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
@@ -18,16 +18,16 @@ public class ContainersConfiguration {
 
    @Bean
    @ServiceConnection
-   KafkaContainer kafkaContainer() {
-      KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
+   ConfluentKafkaContainer kafkaContainer() {
+      ConfluentKafkaContainer kafkaContainer = new ConfluentKafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"))
             .withNetwork(network)
             .withNetworkAliases("kafka")
-            .withListener(() -> "kafka:19092");
+            .withListener("kafka:19092");
       return kafkaContainer;
    }
 
    @Bean
-   MicrocksContainersEnsemble microcksEnsemble(KafkaContainer kafkaContainer) {
+   MicrocksContainersEnsemble microcksEnsemble(ConfluentKafkaContainer kafkaContainer) {
       // Uncomment these lines (36-38) if you want to use the native image of Microcks
       // and comment the next MicrocksContainersEnsemble declaration line (40).
 //      DockerImageName nativeImage = DockerImageName.parse("quay.io/microcks/microcks-uber:1.11.2-native")

--- a/src/test/java/org/acme/order/api/OrderControllerContractTests.java
+++ b/src/test/java/org/acme/order/api/OrderControllerContractTests.java
@@ -6,8 +6,9 @@ import io.github.microcks.testcontainers.model.TestResult;
 import io.github.microcks.testcontainers.model.TestRunnerType;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.acme.order.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,9 @@ class OrderControllerContractTests extends BaseIntegrationTest {
       TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(testRequest);
 
       // You may inspect complete response object with following:
-      ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      ObjectMapper mapper = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .build();
       System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
 
       assertTrue(testResult.isSuccess());
@@ -50,7 +53,9 @@ class OrderControllerContractTests extends BaseIntegrationTest {
       TestResult testResult = microcksEnsemble.getMicrocksContainer().testEndpoint(testRequest);
 
       // You may inspect complete response object with following:
-      ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      ObjectMapper mapper = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .build();
       System.out.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
 
       assertTrue(testResult.isSuccess());

--- a/src/test/java/org/acme/order/api/OrderControllerPostmanContractTests.java
+++ b/src/test/java/org/acme/order/api/OrderControllerPostmanContractTests.java
@@ -5,7 +5,8 @@ import io.github.microcks.testcontainers.model.TestResult;
 import io.github.microcks.testcontainers.model.TestRunnerType;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import org.acme.order.BaseIntegrationTest;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,9 @@ class OrderControllerPostmanContractTests extends BaseIntegrationTest {
       // You may inspect complete response object with following:
       //System.err.println(microcksEnsemble.getMicrocksContainer().getLogs());
       //System.err.println(microcksEnsemble.getPostmanContainer().getLogs());
-      ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      ObjectMapper mapper = JsonMapper.builder()
+            .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .build();
       System.err.println(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(testResult));
 
       assertTrue(testResult.isSuccess());

--- a/src/test/java/org/acme/order/service/OrderServiceTests.java
+++ b/src/test/java/org/acme/order/service/OrderServiceTests.java
@@ -6,8 +6,8 @@ import io.github.microcks.testcontainers.model.TestResult;
 import io.github.microcks.testcontainers.model.TestRunnerType;
 import io.github.microcks.testcontainers.model.UnidirectionalEvent;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
 import org.acme.order.BaseIntegrationTest;
 import org.acme.order.service.model.Order;
 import org.acme.order.service.model.OrderInfo;
@@ -17,7 +17,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 
 import java.time.Duration;
 import java.util.List;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class OrderServiceTests extends BaseIntegrationTest {
 
    @Autowired
-   KafkaContainer kafkaContainer;
+   ConfluentKafkaContainer kafkaContainer;
 
    @Autowired
    OrderService service;
@@ -83,7 +83,7 @@ class OrderServiceTests extends BaseIntegrationTest {
          assertEquals(1, events.size());
 
          EventMessage message = events.get(0).getEventMessage();
-         Map<String, Object> messageMap = new ObjectMapper().readValue(message.getContent(), new TypeReference<>() {});
+         Map<String, Object> messageMap = new JsonMapper().readValue(message.getContent(), new TypeReference<>() {});
 
          // Properties from the event message should match the order.
          assertEquals("Creation", messageMap.get("changeReason"));


### PR DESCRIPTION
### Description

- Migrate Jackson imports from com.fasterxml.jackson to tools.jackson (Jackson 3 new package)                                                                                                                           
- Use immutable JsonMapper.builder() API (Jackson 3 removes mutable ObjectMapper configuration)                                                                                                                         
- Upgrade Testcontainers to 2.x (testcontainers-kafka, ConfluentKafkaContainer)
- Replace spring-kafka with spring-boot-starter-kafka (Kafka auto-config extracted in Spring Boot 4)                                                                                                                    
- Add jackson-databind 2.x for Kafka client backward compatibility                                                                                                                                                      
- Align JUnit versions with Spring Boot BOM, remove unused junit-vintage-engine                                                                                                                                         

### Related issue(s)

- fixes failing Spring Boot Upgrade
   - https://github.com/microcks/microcks-testcontainers-java-spring-demo/pull/126
- and junit bind: 
   - chore(deps-dev): bump org.junit.vintage:junit-vintage-engine from 5.11.4 to 6.0.3 #119
   - chore(deps-dev): bump org.junit.platform:junit-platform-launcher from 1.11.4 to 6.0.3 #118